### PR TITLE
Use patch_size instead of chunk_size as base shape for sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+example.py
 
 # Translations
 *.mo

--- a/docs/source/examples/advanced_example_pytorch_inference.md
+++ b/docs/source/examples/advanced_example_pytorch_inference.md
@@ -1,0 +1,177 @@
+```python
+import zarrdataset as zds
+
+import torch
+from torch.utils.data import DataLoader
+```
+
+
+```python
+# These are images from the Image Data Resource (IDR) 
+# https://idr.openmicroscopy.org/ that are publicly available and were 
+# converted to the OME-NGFF (Zarr) format by the OME group. More examples
+# can be found at Public OME-Zarr data (Nov. 2020)
+# https://www.openmicroscopy.org/2020/11/04/zarr-data.html
+
+filenames = [
+    "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr"
+]
+```
+
+
+```python
+import random
+import numpy as np
+
+# For reproducibility
+np.random.seed(478963)
+torch.manual_seed(478964)
+random.seed(478965)
+```
+
+## Extracting patches of size 1024x1024 pixels from a Whole Slide Image (WSI)
+
+Retrieve samples for inference. Add padding to each patch to avoid edge artifacts when stitching the inference result.
+Finally, let the PatchSampler retrieve patches from the edge of the image that would be otherwise smaller than the patch size.
+
+
+```python
+patch_size = dict(Y=128, X=128)
+pad = dict(Y=16, X=16)
+patch_sampler = zds.PatchSampler(patch_size=patch_size, pad=pad, allow_incomplete_patches=True)
+```
+
+Create a dataset from the list of filenames. All those files should be stored within their respective group "0".
+
+Also, specify that the axes order in the image is Time-Channel-Depth-Height-Width (TCZYX), so the data can be handled correctly
+
+
+```python
+image_specs = zds.ImagesDatasetSpecs(
+  filenames=filenames,
+  data_group="4",
+  source_axes="TCZYX",
+  axes="YXC",
+  roi="0,0,0,0,0:1,-1,1,-1,-1"
+)
+
+my_dataset = zds.ZarrDataset(image_specs,
+                             patch_sampler=patch_sampler,
+                             return_positions=True)
+```
+
+
+```python
+my_dataset
+```
+
+
+
+
+    ZarrDataset (PyTorch support:True, tqdm support :True)
+    Modalities: images
+    Transforms order: []
+    Using images modality as reference.
+    Using <class 'zarrdataset._samplers.PatchSampler'> for sampling patches of size {'Z': 1, 'Y': 128, 'X': 128}.
+
+
+
+Add a pre-processing step before creating the image batches, where the input arrays are casted from int16 to float32.
+
+
+```python
+import torchvision
+
+img_preprocessing = torchvision.transforms.Compose([
+    zds.ToDtype(dtype=np.float32),
+    torchvision.transforms.ToTensor(),
+    torchvision.transforms.Normalize(127, 255)
+])
+
+my_dataset.add_transform("images", img_preprocessing)
+```
+
+
+```python
+my_dataset
+```
+
+
+
+
+    ZarrDataset (PyTorch support:True, tqdm support :True)
+    Modalities: images
+    Transforms order: [('images',)]
+    Using images modality as reference.
+    Using <class 'zarrdataset._samplers.PatchSampler'> for sampling patches of size {'Z': 1, 'Y': 128, 'X': 128}.
+
+
+
+## Create a DataLoader from the dataset object
+
+ZarrDataset is compatible with DataLoader from PyTorch since it is inherited from the IterableDataset class of the torch.utils.data module.
+
+
+```python
+my_dataloader = DataLoader(my_dataset, num_workers=0)
+```
+
+
+```python
+import dask.array as da
+import numpy as np
+import zarr
+
+z_arr = zarr.open("https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr/4", mode="r")
+
+H = z_arr.shape[-2]
+W = z_arr.shape[-1]
+
+pad_H = (128 - H) % 128
+pad_W = (128 - W) % 128
+z_prediction = zarr.zeros((H + pad_H, W + pad_W), dtype=np.float32, chunks=(128, 128))
+z_prediction
+```
+
+
+
+
+    <zarr.core.Array (1152, 1408) float32>
+
+
+
+Set up a simple model for illustration purpose
+
+
+```python
+model = torch.nn.Sequential(
+    torch.nn.Conv2d(in_channels=3, out_channels=1, kernel_size=1),
+    torch.nn.ReLU()
+)
+```
+
+
+```python
+for i, (pos, sample) in enumerate(my_dataloader):
+    pred_pos = (
+        slice(pos[0, 0, 0].item() + 16,
+              pos[0, 0, 1].item() - 16),
+        slice(pos[0, 1, 0].item() + 16,
+              pos[0, 1, 1].item() - 16)
+    )
+    pred = model(sample)
+    z_prediction[pred_pos] = pred.detach().cpu().numpy()[0, 0, 16:-16, 16:-16]
+```
+
+## Visualize the result
+
+
+```python
+import matplotlib.pyplot as plt
+
+plt.subplot(2, 1, 1)
+plt.imshow(np.moveaxis(z_arr[0, :, 0, ...], 0, -1))
+plt.subplot(2, 1, 2)
+plt.imshow(z_prediction)
+plt.show()
+```

--- a/docs/source/examples/advanced_example_pytorch_inference.md
+++ b/docs/source/examples/advanced_example_pytorch_inference.md
@@ -1,3 +1,20 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.15.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+execution:
+  timeout: 120
+---
+
+# Integration of ZarrDataset with PyTorch's DataLoader for inference (Advanced)
+
 ```python
 import zarrdataset as zds
 
@@ -32,7 +49,7 @@ random.seed(478965)
 ## Extracting patches of size 1024x1024 pixels from a Whole Slide Image (WSI)
 
 Retrieve samples for inference. Add padding to each patch to avoid edge artifacts when stitching the inference result.
-Finally, let the PatchSampler retrieve patches from the edge of the image that would be otherwise smaller than the patch size.
+Finally, let the PatchSampler retrieve patches from the edge of the image that would be otherwise smaller than the patch size by setting `allow_incomplete_patches=True`.
 
 
 ```python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,8 @@ Welcome to ZarrDataset's documentation!
 
    examples/advanced_example_pytorch
 
+   examples/advanced_example_pytorch_inference
+
 
 REFERENCE
 =========

--- a/tests/test_imageloaders.py
+++ b/tests/test_imageloaders.py
@@ -163,6 +163,29 @@ def test_ImageBase_slicing():
          f"{expected_selection_shape}, got {img_sel_2.shape} instead")
 
 
+def test_ImageBase_padding():
+    shape = (16, 16, 3)
+    axes = "YXC"
+    img = zds.ImageBase(shape, chunk_size=None, source_axes=axes, mode="image")
+
+    random.seed(44512)
+    selection_1 = dict(
+        (ax, slice(random.randint(-10, 0),
+                   random.randint(1, r_s + 10)))
+        for ax, r_s in zip(axes, shape)
+    )
+
+    expected_selection_shape = tuple(
+        selection_1[ax].stop - selection_1[ax].start for ax in axes
+    )
+
+    img_sel_1 = img[selection_1]
+
+    assert img_sel_1.shape == expected_selection_shape, \
+        (f"Expected selection {selection_1} to have shape "
+         f"{expected_selection_shape}, got {img_sel_1.shape} instead")
+
+
 @pytest.mark.parametrize("axes, roi, expected_size", [
     (None, None, (16, 16, 3)),
     (None, slice(None), (16, 16, 3)),

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -127,6 +127,32 @@ def test_PatchSampler_correct_patch_size(patch_size, spatial_axes,
          f"got {patch_sampler._patch_size} instead.")
 
 
+@pytest.mark.parametrize("stride, spatial_axes, expected_stride", [
+    (512, "X", dict(X=512)),
+    ((128, 64), "XY", dict(X=128, Y=64)),
+])
+def test_PatchSampler_correct_stride(stride, spatial_axes, expected_stride):
+    patch_sampler = zds.PatchSampler(patch_size=512, stride=stride,
+                                     spatial_axes=spatial_axes)
+
+    assert patch_sampler._stride == expected_stride, \
+        (f"Expected `stride` to be a dictionary as {expected_stride}, "
+         f"got {patch_sampler._stride} instead.")
+
+
+@pytest.mark.parametrize("pad, spatial_axes, expected_pad", [
+    (512, "X", dict(X=512)),
+    ((128, 64), "XY", dict(X=128, Y=64)),
+])
+def test_PatchSampler_correct_pad(pad, spatial_axes, expected_pad):
+    patch_sampler = zds.PatchSampler(patch_size=512, pad=pad,
+                                     spatial_axes=spatial_axes)
+
+    assert patch_sampler._pad == expected_pad, \
+        (f"Expected `pad` to be a dictionary as {expected_pad}, "
+         f"got {patch_sampler._pad} instead.")
+
+
 @pytest.mark.parametrize("patch_size, spatial_axes", [
     ((512, 128), "X"),
     ((128, ), "XY"),
@@ -135,6 +161,30 @@ def test_PatchSampler_correct_patch_size(patch_size, spatial_axes,
 def test_PatchSampler_incorrect_patch_size(patch_size, spatial_axes):
     with pytest.raises(ValueError):
         patch_sampler = zds.PatchSampler(patch_size=patch_size,
+                                         spatial_axes=spatial_axes)
+
+
+@pytest.mark.parametrize("stride, spatial_axes", [
+    ((512, 128), "X"),
+    ((128, ), "XY"),
+    ("stride", "ZYX"),
+])
+def test_PatchSampler_incorrect_stride(stride, spatial_axes):
+    with pytest.raises(ValueError):
+        patch_sampler = zds.PatchSampler(patch_size=512,
+                                         stride=stride,
+                                         spatial_axes=spatial_axes)
+
+
+@pytest.mark.parametrize("pad, spatial_axes", [
+    ((512, 128), "X"),
+    ((128, ), "XY"),
+    ("pad", "ZYX"),
+])
+def test_PatchSampler_incorrect_pad(pad, spatial_axes):
+    with pytest.raises(ValueError):
+        patch_sampler = zds.PatchSampler(patch_size=512,
+                                         pad=pad,
                                          spatial_axes=spatial_axes)
 
 

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -354,6 +354,33 @@ def test_PatchSampler_pad(patch_size, pad, image_collection):
          f"{patches_toplefts[:3]} instead.")
 
 
+@pytest.mark.parametrize("patch_size, allow_incomplete_patches,"
+                         "image_collection", [
+    (1024, True, IMAGE_SPECS[10]),
+    (1024, False, IMAGE_SPECS[10]),
+], indirect=["image_collection"])
+def test_PatchSampler_incomplete_patches(patch_size, allow_incomplete_patches,
+                                         image_collection):
+    patch_sampler = zds.PatchSampler(
+        patch_size,
+        allow_incomplete_patches=allow_incomplete_patches
+    )
+
+    chunks_toplefts = patch_sampler.compute_chunks(image_collection)
+
+    patches_toplefts = patch_sampler.compute_patches(
+        image_collection,
+        chunk_tlbr=chunks_toplefts[0]
+    )
+
+    expected_num_patches = 1 if allow_incomplete_patches else 0
+
+    assert len(patches_toplefts) == expected_num_patches,\
+        (f"Expected to have {expected_num_patches}, when "
+         f"`allow_incomplete_patches` is {allow_incomplete_patches} "
+         f"got {len(patches_toplefts)} instead.")
+
+
 @pytest.mark.parametrize("patch_size, axes, resample, allow_overlap,"
                          "image_collection", [
     (dict(X=32, Y=32, Z=1), "XYZ", True, True, IMAGE_SPECS[10]),
@@ -373,15 +400,6 @@ def test_BlueNoisePatchSampler(patch_size, axes, resample, allow_overlap,
     patches_toplefts = patch_sampler.compute_patches(
         image_collection,
         chunk_tlbr=chunks_toplefts[0]
-    )
-
-    assert len(patches_toplefts) == len(patch_sampler._base_chunk_tls), \
-        (f"Expected {len(patch_sampler._base_chunk_tls)} patches, got "
-         f"{len(patches_toplefts)} instead.")
-
-    patches_toplefts = patch_sampler.compute_patches(
-        image_collection,
-        chunk_tlbr=chunks_toplefts[-1]
     )
 
     assert len(patches_toplefts) == len(patch_sampler._base_chunk_tls), \

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -276,7 +276,10 @@ def test_BlueNoisePatchSampler_mask_not2scale(image_collection_mask_not2scale):
         chunk_tlbr=chunks_toplefts[0]
     )
 
-    assert len(patches_toplefts) == 0, \
+    # Samples can be retrieved from chunks that are not multiple of the patch
+    # size. The ZarrDataset class should handle these cases, either by droping
+    # these patches, or by adding padding when allowed by the user.
+    assert len(patches_toplefts) == 1, \
         (f"Expected 0 patches, got {len(patches_toplefts)} instead.")
 
 

--- a/zarrdataset/_samplers.py
+++ b/zarrdataset/_samplers.py
@@ -130,7 +130,7 @@ class PatchSampler(object):
         # with respect to the input image, use the mask coordinates as
         # reference to overlap the coordinates of the sampling patches.
         # Otherwise, use the patches coordinates instead.
-        if all(map(operator.ge, patch_shape, mask_relative_shape)):
+        if all(map(operator.gt, patch_shape, mask_relative_shape)):
             active_coordinates = np.nonzero(chunk_mask)
             ref_axes = mask_axes
 
@@ -138,9 +138,9 @@ class PatchSampler(object):
             shape = mask_relative_shape
 
             mask_is_greater = False
-            
+
             patch_ratio = [
-                    image_size[ax] // ps
+                    round(image_size[ax] / ps)
                     for ax, ps in zip(mask_axes, patch_shape.astype(np.int64))
                     if ax in self.spatial_axes
             ]
@@ -153,7 +153,7 @@ class PatchSampler(object):
 
         else:
             active_coordinates = np.meshgrid(
-                *[np.arange(image_size[ax] // ps)
+                *[np.arange(round(image_size[ax] / ps))
                   for ax, ps in zip(mask_axes, patch_shape)
                   if ax in self.spatial_axes]
             )
@@ -285,7 +285,7 @@ class PatchSampler(object):
         mask = image_collection.collection[image_collection.mask_mode]
 
         spatial_chunk_sizes = dict(
-            (ax, chk)
+            (ax, self._patch_size[ax] * round(chk / self._patch_size[ax]))
             for ax, chk in zip(image.axes, image.chunk_size)
             if ax in self.spatial_axes
         )

--- a/zarrdataset/_samplers.py
+++ b/zarrdataset/_samplers.py
@@ -285,7 +285,8 @@ class PatchSampler(object):
         mask = image_collection.collection[image_collection.mask_mode]
 
         spatial_chunk_sizes = dict(
-            (ax, self._patch_size[ax] * round(chk / self._patch_size[ax]))
+            (ax,
+             self._patch_size[ax] * max(1, round(chk / self._patch_size[ax])))
             for ax, chk in zip(image.axes, image.chunk_size)
             if ax in self.spatial_axes
         )

--- a/zarrdataset/_samplers.py
+++ b/zarrdataset/_samplers.py
@@ -153,7 +153,7 @@ class PatchSampler(object):
 
         else:
             active_coordinates = np.meshgrid(
-                *[np.arange(round(image_size[ax] / ps))
+                *[np.arange(image_size[ax] // ps)
                   for ax, ps in zip(mask_axes, patch_shape)
                   if ax in self.spatial_axes]
             )

--- a/zarrdataset/_samplers.py
+++ b/zarrdataset/_samplers.py
@@ -320,9 +320,7 @@ class PatchSampler(object):
                           + tls[mask.axes.index(ax)] + patch_size[ax])
 
                     curr_tl.append((ax, slice(tl - pad[ax],
-                                              (br if br <= image_shape[ax]
-                                               else image_shape[ax])
-                                              + pad[ax])))
+                                              br + pad[ax])))
 
                 else:
                     curr_tl.append((ax, slice(0, 1)))

--- a/zarrdataset/_zarrdataset.py
+++ b/zarrdataset/_zarrdataset.py
@@ -509,7 +509,7 @@ class ZarrDataset(IterableDataset):
         modes = self._collections.keys()
 
         for collection in zip(*self._collections.values()):
-            collection = dict([(m, c) for m, c in zip(modes, collection)])
+            collection = {m: c for m, c in zip(modes, collection)}
             for mode in collection.keys():
                 collection[mode]["zarr_store"] = self._zarr_store[mode]
                 collection[mode]["image_func"] = self._image_loader_func[mode]
@@ -527,8 +527,8 @@ class ZarrDataset(IterableDataset):
                 toplefts.append(self._patch_sampler.compute_chunks(curr_img))
             else:
                 toplefts.append([
-                    dict((ax, slice(None))
-                         for ax in curr_img.collection[self._ref_mod].axes)
+                    {ax: slice(None)
+                     for ax in curr_img.collection[self._ref_mod].axes}
                     ]
                 )
 


### PR DESCRIPTION
This change allows `zarrdataset` to extract samples using as reference the `patch_size` instead of the input's chunk size.
Basically, chunks are now considered as multiples of `patch_size` and therefore patches can be extracted without separation.
This is helpful when using `zarrdataset` for inference on larger-than-memory inputs.

No changes are needed `ImageBase` class since it can handle loading adjacent chunks. This will increase the memory usage if the patch size is not multiple of the chunk size due to multiple chunks being loaded.

There is no impact on the multi-thread capability of `zarrdataset` to use multiple workers.
That is because each worker has its own handler to access the zarr file, and chunks can be read safely without collisions.
