### PR TITLE
Fix grid missing border patches

### DIFF
--- a/zarrdataset/_samplers.py
+++ b/zarrdataset/_samplers.py
@@ -153,7 +153,7 @@ class PatchSampler(object):
 
         else:
             active_coordinates = np.meshgrid(
-                *[np.arange(image_size[ax] // ps)
+                *[np.arange(np.ceil(image_size[ax] / ps))
                   for ax, ps in zip(mask_axes, patch_shape)
                   if ax in self.spatial_axes]
             )

--- a/zarrdataset/_samplers.py
+++ b/zarrdataset/_samplers.py
@@ -179,14 +179,14 @@ class PatchSampler(object):
 
         if mask_is_greater:
             # The mask ratio is greater than the patches size
-            mask_values = chunk_mask[tuple(corners_idx.T)].T
+            mask_values = chunk_mask[tuple(corners_idx[0].T)].T
             patches_coverage = coverage * mask_values
 
             covered_tls = corners[0, ...].astype(np.int64)
 
         else:
             # The mask ratio is less than the patches size
-            patch_coordinates = np.ravel_multi_index(tuple(corners_idx.T),
+            patch_coordinates = np.ravel_multi_index(tuple(corners_idx[0].T),
                                                      chunk_mask.shape)
             patches_coverage = np.bincount(patch_coordinates.flatten(),
                                            weights=coverage.flatten())

--- a/zarrdataset/_samplers.py
+++ b/zarrdataset/_samplers.py
@@ -250,12 +250,11 @@ class PatchSampler(object):
                     if br <= image_shape[ax]:
                         curr_tl.append((ax, slice(tl, br)))
                     else:
-                        break
+                        curr_tl.append((ax, slice(image_shape[ax]-patch_size[ax], image_shape[ax])))
                 else:
                     curr_tl.append((ax, slice(0, 1)))
 
-            else:
-                toplefts.append(dict(curr_tl))
+            toplefts.append(dict(curr_tl))
 
         return toplefts
 


### PR DESCRIPTION
Attempt to close #5 



This change allows `zarrdataset` to extract all samples even at the border of the image when chunk-zarr is not fully initialized..
This is helpful when using zarrdataset for inference on larger-than-memory inputs.

Potential problems:
- I am not sure to understand why https://github.com/TheJacksonLaboratory/zarrdataset/blob/fb57026a1ed7436603d66b440ab4f9ebfee377f9/zarrdataset/_samplers.py#L74-L91 has to compute several factors. Thus I selected only the first factor when using `corners_idx` here https://github.com/LaboratoryOpticsBiosciences/zarrdataset/blob/0fe3403dc29d99770cea59438e6b05d75438175c/zarrdataset/_samplers.py#L182 and https://github.com/LaboratoryOpticsBiosciences/zarrdataset/blob/0fe3403dc29d99770cea59438e6b05d75438175c/zarrdataset/_samplers.py#L189 (Would it cause problems?)
- Some part of the image might be loaded twice. As work is distrbuted to several workers over chunks, some sample can be present in several chunks.