### PR TITLE
Check if transforms outputs are iterables or arrays

### DIFF
--- a/tests/test_zarrdataset.py
+++ b/tests/test_zarrdataset.py
@@ -286,9 +286,9 @@ def test_ZarrDataset(image_dataset_specs, shuffle, return_positions,
             (f"Sample data type should be numpy.float64, got "
              f"{sample_array.dtype} instead.")
 
-        assert sample_array.shape == tuple(specs["shape"]), \
+        assert tuple(sample_array.shape) == tuple(specs["shape"]), \
             (f"Sample expected to have shape {tuple(specs['shape'])}, got "
-            f"{sample_array.shape} instead")
+            f"{sample_array.shape} ({sample_array.dtype}) instead")
 
         if "labels" in dataset_specs:
             expected_labels_shape = tuple(
@@ -298,9 +298,9 @@ def test_ZarrDataset(image_dataset_specs, shuffle, return_positions,
 
             labels_array = sample[label_idx]
 
-            assert labels_array.shape == expected_labels_shape, \
+            assert tuple(labels_array.shape) == expected_labels_shape, \
                 (f"Labels expected to have shape {expected_labels_shape}, got "
-                f"{labels_array.shape} instead")
+                f"{labels_array.shape} ({labels_array.dtype}) instead")
 
     assert n_samples > 0, ("Expected more than zero samples extracted from "
                            "this experiment.")
@@ -359,11 +359,11 @@ def test_patched_ZarrDataset(image_dataset_specs, patch_sampler_specs,
             for ax in "YX"
         )
 
-        assert sample_array.shape == expected_shape, \
+        assert tuple(sample_array.shape) == expected_shape, \
             (f"Sample expected to have shape {expected_shape}, got "
              f"{sample_array.shape} instead")
 
-        assert labels_array.shape == expected_labels_shape, \
+        assert tuple(labels_array.shape) == expected_labels_shape, \
             (f"Labels expected to have shape {expected_labels_shape}, got "
              f"{labels_array.shape} instead")
 
@@ -399,11 +399,11 @@ def test_patched_ZarrDataset(image_dataset_specs, patch_sampler_specs,
             for ax in "YX"
         )
 
-        assert sample_array.shape == expected_shape, \
+        assert tuple(sample_array.shape) == expected_shape, \
             (f"Sample expected to have shape {expected_shape}, got "
              f"{sample_array.shape} instead")
 
-        assert labels_array.shape == expected_labels_shape, \
+        assert tuple(labels_array.shape) == expected_labels_shape, \
             (f"Labels expected to have shape {expected_labels_shape}, got "
              f"{labels_array.shape} instead")
 
@@ -590,7 +590,7 @@ def test_multithread_chained_ZarrDataset(image_dataset_specs,
         ]
 
         assert all(map(operator.eq,
-                       sample_array.shape,
+                       list(sample_array.shape),
                        expected_shape)), \
             (f"Sample expected to have shape {expected_shape}, got "
              f"{sample_array.shape} instead")

--- a/zarrdataset/_zarrdataset.py
+++ b/zarrdataset/_zarrdataset.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
-from typing import Iterable, Union, Callable
+from collections.abc import Iterable
+from typing import Union, Callable
 from functools import reduce, partial
 import operator
 import random
@@ -564,9 +565,12 @@ class ZarrDataset(IterableDataset):
         patches = self._curr_collection[coords]
 
         for inputs, transform in self._transforms.items():
-            res = transform(*tuple(patches[mode] for mode in inputs))
+            inputs_args = (patches[mode] for mode in inputs)
+            res = transform(*inputs_args)
 
-            if not isinstance(res, tuple):
+            # At this point, any zarr or dask array should have been converted
+            # to numpy array, either by computation or slicing.
+            if isinstance(res, np.ndarray):
                 res = (res, )
 
             for mode, mode_res in zip(inputs, res):


### PR DESCRIPTION
This PR changes the way how results from transforms in the `__getitem__` function of the `ZarrDataset` class are verified.

If the result is a simple `numpy.ndarray`, this is converted to a tuple to make it an iterable variable.
At that point, patches are already extracted and converted to `numpy.ndarray`, either by using `.compute()` on `dask.array.Array's or by slicing `zarr.Array`s.