### PR TITLE
Enabled kwargs to pass padding_mode to the ImageLoader function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ tests/test_zarrs/*
 tests/test_tiffs/*
 tests/*.png
 .vscode/settings.json
+docs/source/examples/tests.qmd

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -86,7 +86,9 @@ def image_dataset_specs(request):
         )
 
     if labels_filenames:
-        dataset_specs[0]["transforms"][("images", )] = zds.ToDtype(np.float32)
+        dataset_specs[0]["transforms"].append(
+            (("images", ), zds.ToDtype(np.float32))
+        )
 
         dataset_specs.append(
             zds.LabelsDatasetSpecs(

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,181 @@
+import pytest
+import os
+import shutil
+from pathlib import Path
+from unittest import mock
+import zarrdataset as zds
+import importlib
+import tqdm
+import numpy as np
+
+import torch
+
+from tests.utils import IMAGE_SPECS
+
+
+def input_target_dtype_fn(input, target):
+    return input.astype(np.float64), target.astype(np.float64)
+
+
+@pytest.fixture(scope="function")
+def image_dataset_specs(request):
+    if not isinstance(request.param, list):
+        params = [request.param]
+    else:
+        params = request.param
+
+    dst_dirs = []
+
+    filenames = []
+    labels_filenames = []
+    mask_filenames = []
+    specs = []
+
+    data_group = None
+    source_axes = None
+    mask_group = None
+    labels_group = None
+
+    for par in params:
+        if isinstance(par["source"], str):
+            dst_dirs.append(None)
+
+        else:
+            dst_dirs.append(par["dst_dir"])
+
+        if dst_dirs[-1] is not None:
+            dst_dir = Path(par["dst_dir"])
+            dst_dir.mkdir(parents=True, exist_ok=True)
+
+        (image_filename,
+         mask_filename,
+         labels_filename,
+         _) = par["source"](par["dst_dir"], par["specs"])
+
+        data_group = par["specs"]["data_group"]
+        source_axes = par["specs"]["source_axes"]
+        filenames.append(image_filename)
+
+        if mask_filename is not None:
+            mask_filenames.append(mask_filename)
+            mask_group = par["specs"]["mask_group"]
+
+        if labels_filename is not None:
+            input_label_transform = input_target_dtype_fn
+            target_transform = zds.ToDtype(np.int64)
+            labels_filenames.append(labels_filename)
+            labels_group = par["specs"]["labels_group"]
+
+        specs.append(par["specs"])
+
+    dataset_specs = [
+        zds.ImagesDatasetSpecs(
+            filenames=filenames,
+            data_group=data_group,
+            source_axes=source_axes,
+        )
+    ]
+
+    if mask_filenames:
+        dataset_specs.append(
+            zds.MasksDatasetSpecs(
+                filenames=mask_filenames,
+                data_group=mask_group,
+                source_axes="YX",
+            )
+        )
+
+    if labels_filenames:
+        dataset_specs[0]["transforms"][("images", )] = zds.ToDtype(np.float32)
+
+        dataset_specs.append(
+            zds.LabelsDatasetSpecs(
+                filenames=labels_filenames,
+                data_group=labels_group,
+                source_axes="YX",
+                transform=target_transform,
+                input_label_transform=input_label_transform,
+            )
+        )
+
+    if len(dataset_specs) == 1:
+        dataset_specs = dataset_specs[0]
+
+    yield dataset_specs, specs[0]
+
+    for dst_dir in dst_dirs:
+        if dst_dir is not None and os.path.isdir(dst_dir):
+            shutil.rmtree(dst_dir)
+
+
+@pytest.fixture(scope="function")
+def patch_sampler_specs(request):
+    patch_size, allow_incomplete_patches = request.param
+    patch_sampler = zds.PatchSampler(
+        patch_size=patch_size,
+        allow_incomplete_patches=allow_incomplete_patches
+    )
+    return patch_sampler, patch_size, allow_incomplete_patches
+
+
+@pytest.mark.parametrize("image_dataset_specs", [
+    IMAGE_SPECS[10],
+], indirect=["image_dataset_specs"])
+def test_compatibility_no_tqdm(image_dataset_specs):
+    with mock.patch.dict('sys.modules', {'tqdm': None}):
+        importlib.reload(zds._zarrdataset)
+
+        assert isinstance(object, type(zds._zarrdataset.tqdm).__bases__), \
+            (f"When `tqdm` is not installed, progress bars should be disabled,"
+             f" and a dummy interface derived from object should be used by "
+             f"ZarrDataset. Got an interface derived from "
+             f"{type(zds._zarrdataset.tqdm).__bases__} instead")
+
+        dataset_specs, _ = image_dataset_specs
+
+        dataset = zds._zarrdataset.ZarrDataset(
+            dataset_specs=dataset_specs,
+            progress_bar=True
+        )
+
+        try:
+            next(iter(dataset))
+
+        except Exception as e:
+            raise AssertionError(f"No exceptions where expected, got {e} "
+                                 f"instead.")
+
+    with mock.patch.dict('sys.modules', {'tqdm': tqdm}):
+        importlib.reload(zds._zarrdataset)
+        importlib.reload(zds)
+
+
+def test_compatibility_no_pytroch():
+    with mock.patch.dict('sys.modules', {'torch': None}):
+        importlib.reload(zds._zarrdataset)
+
+        dataset = zds._zarrdataset.ZarrDataset()
+
+        assert isinstance(object, type(dataset).__bases__), \
+            (f"When pytorch is not installed, ZarrDataset should be inherited"
+             f" from object, not {type(dataset).__bases__}")
+
+        try:
+            zds._zarrdataset.zarrdataset_worker_init_fn(None)
+
+        except Exception as e:
+            raise AssertionError(f"No exceptions where expected when using "
+                                 f"`zarrdataset_worker_init_fn` without "
+                                 f"pytorch installed, got {e} instead.")
+
+        try:
+            zds._zarrdataset.chained_zarrdataset_worker_init_fn(None)
+
+        except Exception as e:
+            raise AssertionError(f"No exceptions where expected when using "
+                                 f"`chained_zarrdataset_worker_init_fn` "
+                                 f"without pytorch installed, got {e} "
+                                 f"instead.")
+    with mock.patch.dict('sys.modules', {'torch': torch}):
+        importlib.reload(zds._zarrdataset)
+        importlib.reload(zds)

--- a/tests/test_multithreading.py
+++ b/tests/test_multithreading.py
@@ -86,7 +86,9 @@ def image_dataset_specs(request):
         )
 
     if labels_filenames:
-        dataset_specs[0]["transforms"][("images", )] = zds.ToDtype(np.float32)
+        dataset_specs[0]["transforms"].append(
+            (("images", ), zds.ToDtype(np.float32))
+        )
 
         dataset_specs.append(
             zds.LabelsDatasetSpecs(

--- a/tests/test_multithreading.py
+++ b/tests/test_multithreading.py
@@ -1,0 +1,282 @@
+import pytest
+import os
+import shutil
+from pathlib import Path
+import operator
+
+import zarrdataset as zds
+import numpy as np
+
+from tests.utils import IMAGE_SPECS
+
+import torch
+from torch.utils.data import DataLoader, ChainDataset
+
+
+def input_target_dtype_fn(input, target):
+    return input.astype(np.float64), target.astype(np.float64)
+
+
+@pytest.fixture(scope="function")
+def image_dataset_specs(request):
+    if not isinstance(request.param, list):
+        params = [request.param]
+    else:
+        params = request.param
+
+    dst_dirs = []
+
+    filenames = []
+    labels_filenames = []
+    mask_filenames = []
+    specs = []
+
+    data_group = None
+    source_axes = None
+    mask_group = None
+    labels_group = None
+
+    for par in params:
+        if isinstance(par["source"], str):
+            dst_dirs.append(None)
+
+        else:
+            dst_dirs.append(par["dst_dir"])
+
+        if dst_dirs[-1] is not None:
+            dst_dir = Path(par["dst_dir"])
+            dst_dir.mkdir(parents=True, exist_ok=True)
+
+        (image_filename,
+         mask_filename,
+         labels_filename,
+         _) = par["source"](par["dst_dir"], par["specs"])
+
+        data_group = par["specs"]["data_group"]
+        source_axes = par["specs"]["source_axes"]
+        filenames.append(image_filename)
+
+        if mask_filename is not None:
+            mask_filenames.append(mask_filename)
+            mask_group = par["specs"]["mask_group"]
+
+        if labels_filename is not None:
+            input_label_transform = input_target_dtype_fn
+            target_transform = zds.ToDtype(np.int64)
+            labels_filenames.append(labels_filename)
+            labels_group = par["specs"]["labels_group"]
+
+        specs.append(par["specs"])
+
+    dataset_specs = [
+        zds.ImagesDatasetSpecs(
+            filenames=filenames,
+            data_group=data_group,
+            source_axes=source_axes,
+        )
+    ]
+
+    if mask_filenames:
+        dataset_specs.append(
+            zds.MasksDatasetSpecs(
+                filenames=mask_filenames,
+                data_group=mask_group,
+                source_axes="YX",
+            )
+        )
+
+    if labels_filenames:
+        dataset_specs[0]["transforms"][("images", )] = zds.ToDtype(np.float32)
+
+        dataset_specs.append(
+            zds.LabelsDatasetSpecs(
+                filenames=labels_filenames,
+                data_group=labels_group,
+                source_axes="YX",
+                transform=target_transform,
+                input_label_transform=input_label_transform,
+            )
+        )
+
+    if len(dataset_specs) == 1:
+        dataset_specs = dataset_specs[0]
+
+    yield dataset_specs, specs[0]
+
+    for dst_dir in dst_dirs:
+        if dst_dir is not None and os.path.isdir(dst_dir):
+            shutil.rmtree(dst_dir)
+
+
+@pytest.fixture(scope="function")
+def patch_sampler_specs(request):
+    patch_size, allow_incomplete_patches = request.param
+    patch_sampler = zds.PatchSampler(
+        patch_size=patch_size,
+        allow_incomplete_patches=allow_incomplete_patches
+    )
+    return patch_sampler, patch_size, allow_incomplete_patches
+
+
+@pytest.mark.parametrize(
+    "image_dataset_specs, patch_sampler_specs, shuffle, draw_same_chunk,"
+    "batch_size, num_workers", [
+        (IMAGE_SPECS[10], (32, False), True, False, 2, 2),
+        ([IMAGE_SPECS[10]] * 4, (32, False), True, True, 2, 3),
+        ([IMAGE_SPECS[10]] * 2, (32, False), True, True, 2, 3),
+    ],
+    indirect=["image_dataset_specs", "patch_sampler_specs"]
+)
+def test_multithread_ZarrDataset(image_dataset_specs, patch_sampler_specs,
+                                 shuffle,
+                                 draw_same_chunk,
+                                 batch_size,
+                                 num_workers):
+    dataset_specs, specs = image_dataset_specs
+
+    patch_sampler, patch_size, allow_incomplete_patches = patch_sampler_specs
+
+    ds = zds.ZarrDataset(
+        dataset_specs=dataset_specs,
+        shuffle=shuffle,
+        patch_sampler=patch_sampler,
+        draw_same_chunk=draw_same_chunk
+    )
+
+    dl = DataLoader(
+        ds,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        worker_init_fn=zds.zarrdataset_worker_init_fn,
+        drop_last=True
+    )
+
+    array_idx = 0
+    label_idx = 1
+
+    n_samples = 0
+
+    for sample in dl:
+        n_samples += 1
+        assert isinstance(sample, list), \
+            (f"When a labels dataset specification is passed to ZarrDataset "
+             f"and used with PyTorch DataLoader, samples should be a list, got"
+             f" {type(sample)} instead.")
+
+        assert isinstance(sample[0], torch.Tensor), \
+            (f"Sample should be a PyTorch Tensor, got {type(sample[0])} "
+             f"instead.")
+
+        sample_array = sample[array_idx]
+        labels_array = sample[label_idx]
+
+        expected_shape = [batch_size] + [
+            min(patch_size, specs["shape"][specs["source_axes"].index(ax)])
+            if ax in patch_sampler.spatial_axes else
+            specs["shape"][specs["source_axes"].index(ax)]
+            for ax in specs["source_axes"]
+        ]
+
+        expected_labels_shape = [batch_size] + [
+            patch_size if ax in patch_sampler.spatial_axes else
+            specs["shape"]["YX".index(ax)]
+            for ax in "YX"
+        ]
+
+        assert all(map(operator.eq,
+                       sample_array.shape,
+                       expected_shape)), \
+            (f"Sample expected to have shape {expected_shape}, got "
+             f"{sample_array.shape} instead")
+
+        assert all(map(operator.eq,
+                       labels_array.shape,
+                       expected_labels_shape)), \
+            (f"Labels expected to have shape {expected_labels_shape}, got "
+             f"{labels_array.shape} instead")
+
+    assert n_samples > 0, ("Expected more than zero samples extracted from "
+                           "this experiment.")
+
+
+@pytest.mark.parametrize(
+    "image_dataset_specs, patch_sampler_specs, shuffle, draw_same_chunk,"
+    "batch_size, num_workers, repeat_dataset", [
+        (IMAGE_SPECS[10:12], (32, False), True, False, 2, 2, 1),
+        (IMAGE_SPECS[10:12], (32, False), True, False, 2, 2, 2),
+        (IMAGE_SPECS[10:12], (32, False), True, False, 2, 2, 3),
+    ],
+    indirect=["image_dataset_specs", "patch_sampler_specs"]
+)
+def test_multithread_chained_ZarrDataset(image_dataset_specs,
+                                         patch_sampler_specs,
+                                         shuffle,
+                                         draw_same_chunk,
+                                         batch_size,
+                                         num_workers,
+                                         repeat_dataset):
+    dataset_specs, specs = image_dataset_specs
+    patch_sampler, patch_size, allow_incomplete_patches = patch_sampler_specs
+
+    ds = [zds.ZarrDataset(dataset_specs=dataset_specs,
+                          shuffle=shuffle,
+                          patch_sampler=patch_sampler,
+                          draw_same_chunk=draw_same_chunk)
+          ] * repeat_dataset
+
+    chained_ds = ChainDataset(ds)
+
+    dl = DataLoader(
+        chained_ds,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        worker_init_fn=zds.chained_zarrdataset_worker_init_fn,
+        drop_last=True
+    )
+
+    array_idx = 0
+    label_idx = 1
+
+    n_samples = 0
+
+    for sample in dl:
+        n_samples += 1
+        assert isinstance(sample, list), \
+            (f"When a labels dataset specification is passed to ZarrDataset "
+             f"and used with PyTorch DataLoader, samples should be a list, got"
+             f" {type(sample)} instead.")
+
+        assert isinstance(sample[0], torch.Tensor), \
+            (f"Sample should be a PyTorch Tensor, got {type(sample[0])} "
+             f"instead.")
+
+        sample_array = sample[array_idx]
+        labels_array = sample[label_idx]
+
+        expected_shape = [batch_size] + [
+            min(patch_size, specs["shape"][specs["source_axes"].index(ax)])
+            if ax in patch_sampler.spatial_axes else
+            specs["shape"][specs["source_axes"].index(ax)]
+            for ax in specs["source_axes"]
+        ]
+
+        expected_labels_shape = [batch_size] + [
+            patch_size if ax in patch_sampler.spatial_axes else
+            specs["shape"]["YX".index(ax)]
+            for ax in "YX"
+        ]
+
+        assert all(map(operator.eq,
+                       list(sample_array.shape),
+                       expected_shape)), \
+            (f"Sample expected to have shape {expected_shape}, got "
+             f"{sample_array.shape} instead")
+
+        assert all(map(operator.eq,
+                       labels_array.shape,
+                       expected_labels_shape)), \
+            (f"Labels expected to have shape {expected_labels_shape}, got "
+             f"{labels_array.shape} instead")
+
+    assert n_samples > 0, ("Expected more than zero samples extracted from "
+                           "this experiment.")

--- a/tests/test_patchsamplers.py
+++ b/tests/test_patchsamplers.py
@@ -81,7 +81,9 @@ def image_dataset_specs(request):
         )
 
     if labels_filenames:
-        dataset_specs[0]["transforms"][("images", )] = zds.ToDtype(np.float32)
+        dataset_specs[0]["transforms"].append(
+            (("images", ), zds.ToDtype(np.float32))
+        )
 
         dataset_specs.append(
             zds.LabelsDatasetSpecs(

--- a/tests/test_patchsamplers.py
+++ b/tests/test_patchsamplers.py
@@ -1,0 +1,248 @@
+import pytest
+import os
+import shutil
+from pathlib import Path
+import zarrdataset as zds
+import numpy as np
+
+from tests.utils import IMAGE_SPECS
+
+
+def input_target_dtype_fn(input, target):
+    return input.astype(np.float64), target.astype(np.float64)
+
+
+@pytest.fixture(scope="function")
+def image_dataset_specs(request):
+    if not isinstance(request.param, list):
+        params = [request.param]
+    else:
+        params = request.param
+
+    dst_dirs = []
+
+    filenames = []
+    labels_filenames = []
+    mask_filenames = []
+    specs = []
+
+    data_group = None
+    source_axes = None
+    mask_group = None
+    labels_group = None
+
+    for par in params:
+        if isinstance(par["source"], str):
+            dst_dirs.append(None)
+
+        else:
+            dst_dirs.append(par["dst_dir"])
+
+        if dst_dirs[-1] is not None:
+            dst_dir = Path(par["dst_dir"])
+            dst_dir.mkdir(parents=True, exist_ok=True)
+
+        (image_filename,
+         mask_filename,
+         labels_filename,
+         _) = par["source"](par["dst_dir"], par["specs"])
+
+        data_group = par["specs"]["data_group"]
+        source_axes = par["specs"]["source_axes"]
+        filenames.append(image_filename)
+
+        if mask_filename is not None:
+            mask_filenames.append(mask_filename)
+            mask_group = par["specs"]["mask_group"]
+
+        if labels_filename is not None:
+            input_label_transform = input_target_dtype_fn
+            target_transform = zds.ToDtype(np.int64)
+            labels_filenames.append(labels_filename)
+            labels_group = par["specs"]["labels_group"]
+
+        specs.append(par["specs"])
+
+    dataset_specs = [
+        zds.ImagesDatasetSpecs(
+            filenames=filenames,
+            data_group=data_group,
+            source_axes=source_axes,
+        )
+    ]
+
+    if mask_filenames:
+        dataset_specs.append(
+            zds.MasksDatasetSpecs(
+                filenames=mask_filenames,
+                data_group=mask_group,
+                source_axes="YX",
+            )
+        )
+
+    if labels_filenames:
+        dataset_specs[0]["transforms"][("images", )] = zds.ToDtype(np.float32)
+
+        dataset_specs.append(
+            zds.LabelsDatasetSpecs(
+                filenames=labels_filenames,
+                data_group=labels_group,
+                source_axes="YX",
+                transform=target_transform,
+                input_label_transform=input_label_transform,
+            )
+        )
+
+    if len(dataset_specs) == 1:
+        dataset_specs = dataset_specs[0]
+
+    yield dataset_specs, specs[0]
+
+    for dst_dir in dst_dirs:
+        if dst_dir is not None and os.path.isdir(dst_dir):
+            shutil.rmtree(dst_dir)
+
+
+@pytest.fixture(scope="function")
+def patch_sampler_specs(request):
+    patch_size, allow_incomplete_patches = request.param
+    patch_sampler = zds.PatchSampler(
+        patch_size=patch_size,
+        allow_incomplete_patches=allow_incomplete_patches
+    )
+    return patch_sampler, patch_size, allow_incomplete_patches
+
+
+@pytest.mark.parametrize(
+    "image_dataset_specs, patch_sampler_specs, shuffle, draw_same_chunk", [
+        (IMAGE_SPECS[10], (32, False), True, False),
+        (IMAGE_SPECS[10], (32, False), True, True),
+        (IMAGE_SPECS[10], (32, False), False, True),
+    ],
+    indirect=["image_dataset_specs", "patch_sampler_specs"]
+)
+def test_patched_ZarrDataset(image_dataset_specs, patch_sampler_specs,
+                             shuffle,
+                             draw_same_chunk):
+    dataset_specs, specs = image_dataset_specs
+    patch_sampler, patch_size, allow_incomplete_patches = patch_sampler_specs
+
+    ds = zds.ZarrDataset(
+        dataset_specs=dataset_specs,
+        shuffle=shuffle,
+        patch_sampler=patch_sampler,
+        draw_same_chunk=draw_same_chunk
+    )
+
+    array_idx = 0
+    label_idx = 1
+
+    n_samples = 0
+
+    for sample in ds:
+        n_samples += 1
+        assert isinstance(sample, tuple), \
+            (f"When `return_positions`, `return_worker_id` or a labels dataset"
+             f" specification is passed to ZarrDataset, retrieved samples "
+             f"should be a tuple, got {type(sample)} instead.")
+
+        assert isinstance(sample[0], np.ndarray), \
+            (f"Sample should be a Numpy NDArray, got {type(sample[0])} "
+             f"instead.")
+
+        sample_array = sample[array_idx]
+        labels_array = sample[label_idx]
+
+        expected_shape = tuple(
+            min(patch_size, specs["shape"][specs["source_axes"].index(ax)])
+            if ax in patch_sampler.spatial_axes else
+            specs["shape"][specs["source_axes"].index(ax)]
+            for ax in specs["source_axes"]
+        )
+
+        expected_labels_shape = tuple(
+            patch_size if ax in patch_sampler.spatial_axes else
+            specs["shape"]["YX".index(ax)]
+            for ax in "YX"
+        )
+
+        assert tuple(sample_array.shape) == expected_shape, \
+            (f"Sample expected to have shape {expected_shape}, got "
+             f"{sample_array.shape} instead")
+
+        assert tuple(labels_array.shape) == expected_labels_shape, \
+            (f"Labels expected to have shape {expected_labels_shape}, got "
+             f"{labels_array.shape} instead")
+
+    assert n_samples > 0, ("Expected more than zero samples extracted from "
+                           "this experiment.")
+
+    # Second iteration
+    n_samples = 0
+    for sample in ds:
+        n_samples += 1
+        assert isinstance(sample, tuple), \
+            (f"When `return_positions`, `return_worker_id` or a labels dataset"
+             f" specification is passed to ZarrDataset, retrieved samples "
+             f"should be a tuple, got {type(sample)} instead.")
+
+        assert isinstance(sample[0], np.ndarray), \
+            (f"Sample should be a Numpy NDArray, got {type(sample[0])} "
+             f"instead.")
+
+        sample_array = sample[array_idx]
+        labels_array = sample[label_idx]
+
+        expected_shape = tuple(
+            min(patch_size, specs["shape"][specs["source_axes"].index(ax)])
+            if ax in patch_sampler.spatial_axes else
+            specs["shape"][specs["source_axes"].index(ax)]
+            for ax in specs["source_axes"]
+        )
+
+        expected_labels_shape = tuple(
+            patch_size if ax in patch_sampler.spatial_axes else
+            specs["shape"]["YX".index(ax)]
+            for ax in "YX"
+        )
+
+        assert tuple(sample_array.shape) == expected_shape, \
+            (f"Sample expected to have shape {expected_shape}, got "
+             f"{sample_array.shape} instead")
+
+        assert tuple(labels_array.shape) == expected_labels_shape, \
+            (f"Labels expected to have shape {expected_labels_shape}, got "
+             f"{labels_array.shape} instead")
+
+    assert n_samples > 0, ("Expected more than zero samples extracted from "
+                           "this experiment.")
+
+
+@pytest.mark.parametrize(
+    "image_dataset_specs, patch_sampler_specs", [
+        (IMAGE_SPECS[10], (1024, True)),
+        (IMAGE_SPECS[10], (1024, False)),
+    ],
+    indirect=["image_dataset_specs", "patch_sampler_specs"]
+)
+def test_greater_patch_ZarrDataset(image_dataset_specs, patch_sampler_specs):
+    dataset_specs, specs = image_dataset_specs
+    patch_sampler, patch_size, allow_incomplete_patches = patch_sampler_specs
+
+    ds = zds.ZarrDataset(
+        dataset_specs=dataset_specs,
+        patch_sampler=patch_sampler
+    )
+
+    n_samples = 0
+    for _ in ds:
+        n_samples += 1
+
+    if allow_incomplete_patches:
+        assert n_samples > 0, ("Expected at elast one sample when patch"
+                               " size is greater than the image size, and"
+                               " `allow_incomplete_patches` is True.")
+    else:
+        assert n_samples == 0, ("Expected zero samples since requested patch"
+                                " size is greater than the image size, and"
+                                " `allow_incomplete_patches` is False.")

--- a/tests/test_zarrdataset.py
+++ b/tests/test_zarrdataset.py
@@ -317,39 +317,3 @@ def test_ZarrDataset(image_dataset_specs, shuffle, return_positions,
 
     assert n_samples > 0, ("Expected more than zero samples extracted from "
                            "this experiment.")
-
-
-@pytest.mark.parametrize(
-    "image_dataset_specs", [
-        IMAGE_SPECS[6],
-    ],
-    indirect=["image_dataset_specs"]
-)
-def test_transforms_lists(image_dataset_specs):
-    dataset_specs, specs = image_dataset_specs
-
-    ds = zds.ZarrDataset(
-        dataset_specs=dataset_specs
-    )
-
-    ds.add_transform(("images", ), zds.ToDtype(np.float64))
-    ds.add_transform(("images", ), zds.ToDtype(np.float64))
-
-    assert len(ds._transforms[(dataset_specs["modality"], )]) == 1, \
-        (f"Expected only one transform to be added to the dataset, got "
-         f"{len(ds._transforms)} instead.")
-
-    ds.add_transform(("images", ), zds.ToDtype(np.float64))
-    ds.add_transform(("images", ), zds.ToDtype(np.float32),
-                     append=True)
-
-    assert len(ds._transforms[(dataset_specs["modality"], )]) == 2, \
-        (f"Expected two transforms to be added to the dataset, got "
-         f"{len(ds._transforms)} instead.")
-
-    ds_iter = iter(ds)
-    sample = next(ds_iter)
-
-    assert sample[0].dtype == np.float32, \
-        (f"Expected sample to have data type numpy.float32 after applying two "
-         f"consecutive data type transforms, got {sample[0].dtype} instead.")

--- a/tests/test_zarrdataset.py
+++ b/tests/test_zarrdataset.py
@@ -2,21 +2,13 @@ import pytest
 import os
 import shutil
 from pathlib import Path
-from unittest import mock
 from collections import OrderedDict
 from _collections_abc import dict_items
 
-import operator
-
 import zarrdataset as zds
-import importlib
-import tqdm
 import numpy as np
 
 from tests.utils import IMAGE_SPECS
-
-import torch
-from torch.utils.data import DataLoader, ChainDataset
 
 
 def input_target_dtype_fn(input, target):
@@ -124,38 +116,6 @@ def patch_sampler_specs(request):
     return patch_sampler, patch_size, allow_incomplete_patches
 
 
-@pytest.mark.parametrize("image_dataset_specs", [
-    IMAGE_SPECS[10],
-], indirect=["image_dataset_specs"])
-def test_compatibility_no_tqdm(image_dataset_specs):
-    with mock.patch.dict('sys.modules', {'tqdm': None}):
-        importlib.reload(zds._zarrdataset)
-
-        assert isinstance(object, type(zds._zarrdataset.tqdm).__bases__), \
-            (f"When `tqdm` is not installed, progress bars should be disabled,"
-             f" and a dummy interface derived from object should be used by "
-             f"ZarrDataset. Got an interface derived from "
-             f"{type(zds._zarrdataset.tqdm).__bases__} instead")
-
-        dataset_specs, _ = image_dataset_specs
-
-        dataset = zds._zarrdataset.ZarrDataset(
-            dataset_specs=dataset_specs,
-            progress_bar=True
-        )
-
-        try:
-            next(iter(dataset))
-
-        except Exception as e:
-            raise AssertionError(f"No exceptions where expected, got {e} "
-                                 f"instead.")
-
-    with mock.patch.dict('sys.modules', {'tqdm': tqdm}):
-        importlib.reload(zds._zarrdataset)
-        importlib.reload(zds)
-
-
 @pytest.mark.parametrize("dataset_spec_class", [
     zds.DatasetSpecs,
     zds.ImagesDatasetSpecs,
@@ -182,7 +142,7 @@ def test_DataSpecs(dataset_spec_class):
     assert isinstance(generic_specs["transforms"], OrderedDict),\
         (f"Expected transforms to be an ordered dicionary, got "
          f"{type(generic_specs['transforms'])} instead.")
-    
+
     assert isinstance(generic_specs.items(), dict_items),\
         (f"Expected DatasetSpecs to return `dict_items` when called `.items()`"
          f", got {type(generic_specs.items())} instead.")
@@ -266,8 +226,8 @@ def test_ZarrDataset(image_dataset_specs, shuffle, return_positions,
     for sample in ds:
         n_samples += 1
         if (any(["labels" in mode["modality"] for mode in dataset_specs])
-          or return_positions
-          or return_worker_id):
+           or return_positions
+           or return_worker_id):
             assert isinstance(sample, tuple), \
                 (f"When `return_positions`, `return_worker_id` or a labels "
                  f"dataset specification is passed to ZarrDataset, retrieved "
@@ -288,7 +248,7 @@ def test_ZarrDataset(image_dataset_specs, shuffle, return_positions,
 
         assert tuple(sample_array.shape) == tuple(specs["shape"]), \
             (f"Sample expected to have shape {tuple(specs['shape'])}, got "
-            f"{sample_array.shape} ({sample_array.dtype}) instead")
+             f"{sample_array.shape} ({sample_array.dtype}) instead")
 
         if "labels" in dataset_specs:
             expected_labels_shape = tuple(
@@ -300,337 +260,43 @@ def test_ZarrDataset(image_dataset_specs, shuffle, return_positions,
 
             assert tuple(labels_array.shape) == expected_labels_shape, \
                 (f"Labels expected to have shape {expected_labels_shape}, got "
-                f"{labels_array.shape} ({labels_array.dtype}) instead")
+                 f"{labels_array.shape} ({labels_array.dtype}) instead")
 
     assert n_samples > 0, ("Expected more than zero samples extracted from "
                            "this experiment.")
 
 
 @pytest.mark.parametrize(
-    "image_dataset_specs, patch_sampler_specs, shuffle, draw_same_chunk", [
-        (IMAGE_SPECS[10], (32, False), True, False),
-        (IMAGE_SPECS[10], (32, False), True, True),
-        (IMAGE_SPECS[10], (32, False), False, True),
+    "image_dataset_specs", [
+        IMAGE_SPECS[6],
     ],
-    indirect=["image_dataset_specs", "patch_sampler_specs"]
+    indirect=["image_dataset_specs"]
 )
-def test_patched_ZarrDataset(image_dataset_specs, patch_sampler_specs,
-                             shuffle,
-                             draw_same_chunk):
+def test_transforms_lists(image_dataset_specs):
     dataset_specs, specs = image_dataset_specs
-    patch_sampler, patch_size, allow_incomplete_patches = patch_sampler_specs
 
     ds = zds.ZarrDataset(
-        dataset_specs=dataset_specs,
-        shuffle=shuffle,
-        patch_sampler=patch_sampler,
-        draw_same_chunk=draw_same_chunk
+        dataset_specs=dataset_specs
     )
 
-    array_idx = 0
-    label_idx = 1
+    ds.add_transform(("images", ), zds.ToDtype(np.float64))
+    ds.add_transform(("images", ), zds.ToDtype(np.float64))
 
-    n_samples = 0
+    assert len(ds._transforms[(dataset_specs["modality"], )]) == 1, \
+        (f"Expected only one transform to be added to the dataset, got "
+         f"{len(ds._transforms)} instead.")
 
-    for sample in ds:
-        n_samples += 1
-        assert isinstance(sample, tuple), \
-            (f"When `return_positions`, `return_worker_id` or a labels dataset"
-             f" specification is passed to ZarrDataset, retrieved samples "
-             f"should be a tuple, got {type(sample)} instead.")
+    ds.add_transform(("images", ), zds.ToDtype(np.float64))
+    ds.add_transform(("images", ), zds.ToDtype(np.float32),
+                     append=True)
 
-        assert isinstance(sample[0], np.ndarray), \
-            (f"Sample should be a Numpy NDArray, got {type(sample[0])} "
-             f"instead.")
+    assert len(ds._transforms[(dataset_specs["modality"], )]) == 2, \
+        (f"Expected two transforms to be added to the dataset, got "
+         f"{len(ds._transforms)} instead.")
 
-        sample_array = sample[array_idx]
-        labels_array = sample[label_idx]
+    ds_iter = iter(ds)
+    sample = next(ds_iter)
 
-        expected_shape = tuple(
-            min(patch_size, specs["shape"][specs["source_axes"].index(ax)])
-            if ax in patch_sampler.spatial_axes else
-            specs["shape"][specs["source_axes"].index(ax)]
-            for ax in specs["source_axes"]
-        )
-
-        expected_labels_shape = tuple(
-            patch_size if ax in patch_sampler.spatial_axes else
-            specs["shape"]["YX".index(ax)]
-            for ax in "YX"
-        )
-
-        assert tuple(sample_array.shape) == expected_shape, \
-            (f"Sample expected to have shape {expected_shape}, got "
-             f"{sample_array.shape} instead")
-
-        assert tuple(labels_array.shape) == expected_labels_shape, \
-            (f"Labels expected to have shape {expected_labels_shape}, got "
-             f"{labels_array.shape} instead")
-
-    assert n_samples > 0, ("Expected more than zero samples extracted from "
-                           "this experiment.")
-
-    # Second iteration
-    n_samples = 0
-    for sample in ds:
-        n_samples += 1
-        assert isinstance(sample, tuple), \
-            (f"When `return_positions`, `return_worker_id` or a labels dataset"
-             f" specification is passed to ZarrDataset, retrieved samples "
-             f"should be a tuple, got {type(sample)} instead.")
-
-        assert isinstance(sample[0], np.ndarray), \
-            (f"Sample should be a Numpy NDArray, got {type(sample[0])} "
-             f"instead.")
-
-        sample_array = sample[array_idx]
-        labels_array = sample[label_idx]
-
-        expected_shape = tuple(
-            min(patch_size, specs["shape"][specs["source_axes"].index(ax)])
-            if ax in patch_sampler.spatial_axes else
-            specs["shape"][specs["source_axes"].index(ax)]
-            for ax in specs["source_axes"]
-        )
-
-        expected_labels_shape = tuple(
-            patch_size if ax in patch_sampler.spatial_axes else
-            specs["shape"]["YX".index(ax)]
-            for ax in "YX"
-        )
-
-        assert tuple(sample_array.shape) == expected_shape, \
-            (f"Sample expected to have shape {expected_shape}, got "
-             f"{sample_array.shape} instead")
-
-        assert tuple(labels_array.shape) == expected_labels_shape, \
-            (f"Labels expected to have shape {expected_labels_shape}, got "
-             f"{labels_array.shape} instead")
-
-    assert n_samples > 0, ("Expected more than zero samples extracted from "
-                           "this experiment.")
-
-
-@pytest.mark.parametrize(
-    "image_dataset_specs, patch_sampler_specs", [
-        (IMAGE_SPECS[10], (1024, True)),
-        (IMAGE_SPECS[10], (1024, False)),
-    ],
-    indirect=["image_dataset_specs", "patch_sampler_specs"]
-)
-def test_greater_patch_ZarrDataset(image_dataset_specs, patch_sampler_specs):
-    dataset_specs, specs = image_dataset_specs
-    patch_sampler, patch_size, allow_incomplete_patches = patch_sampler_specs
-
-    ds = zds.ZarrDataset(
-        dataset_specs=dataset_specs,
-        patch_sampler=patch_sampler
-    )
-
-    n_samples = 0
-    for _ in ds:
-        n_samples += 1
-
-    if allow_incomplete_patches:
-        assert n_samples > 0, ("Expected at elast one sample when patch"
-                               " size is greater than the image size, and"
-                               " `allow_incomplete_patches` is True.")
-    else:
-        assert n_samples == 0, ("Expected zero samples since requested patch"
-                                " size is greater than the image size, and"
-                                " `allow_incomplete_patches` is False.")
-
-
-@pytest.mark.parametrize(
-    "image_dataset_specs, patch_sampler_specs, shuffle, draw_same_chunk,"
-    "batch_size, num_workers", [
-        (IMAGE_SPECS[10], (32, False), True, False, 2, 2),
-        ([IMAGE_SPECS[10]] * 4, (32, False), True, True, 2, 3),
-        ([IMAGE_SPECS[10]] * 2, (32, False), True, True, 2, 3),
-    ],
-    indirect=["image_dataset_specs", "patch_sampler_specs"]
-)
-def test_multithread_ZarrDataset(image_dataset_specs, patch_sampler_specs,
-                                 shuffle,
-                                 draw_same_chunk,
-                                 batch_size,
-                                 num_workers):
-    dataset_specs, specs = image_dataset_specs
-
-    patch_sampler, patch_size, allow_incomplete_patches = patch_sampler_specs
-
-    ds = zds.ZarrDataset(
-        dataset_specs=dataset_specs,
-        shuffle=shuffle,
-        patch_sampler=patch_sampler,
-        draw_same_chunk=draw_same_chunk
-    )
-
-    dl = DataLoader(
-        ds,
-        batch_size=batch_size,
-        num_workers=num_workers,
-        worker_init_fn=zds.zarrdataset_worker_init_fn,
-        drop_last=True
-    )
-
-    array_idx = 0
-    label_idx = 1
-
-    n_samples = 0
-
-    for sample in dl:
-        n_samples += 1
-        assert isinstance(sample, list), \
-            (f"When a labels dataset specification is passed to ZarrDataset "
-             f"and used with PyTorch DataLoader, samples should be a list, got"
-             f" {type(sample)} instead.")
-
-        assert isinstance(sample[0], torch.Tensor), \
-            (f"Sample should be a PyTorch Tensor, got {type(sample[0])} "
-             f"instead.")
-
-        sample_array = sample[array_idx]
-        labels_array = sample[label_idx]
-
-        expected_shape = [batch_size] + [
-            min(patch_size, specs["shape"][specs["source_axes"].index(ax)])
-            if ax in patch_sampler.spatial_axes else
-            specs["shape"][specs["source_axes"].index(ax)]
-            for ax in specs["source_axes"]
-        ]
-
-        expected_labels_shape = [batch_size] + [
-            patch_size if ax in patch_sampler.spatial_axes else
-            specs["shape"]["YX".index(ax)]
-            for ax in "YX"
-        ]
-
-        assert all(map(operator.eq,
-                       sample_array.shape,
-                       expected_shape)), \
-            (f"Sample expected to have shape {expected_shape}, got "
-             f"{sample_array.shape} instead")
-
-        assert all(map(operator.eq,
-                       labels_array.shape,
-                       expected_labels_shape)), \
-            (f"Labels expected to have shape {expected_labels_shape}, got "
-             f"{labels_array.shape} instead")
-
-    assert n_samples > 0, ("Expected more than zero samples extracted from "
-                           "this experiment.")
-
-
-@pytest.mark.parametrize(
-    "image_dataset_specs, patch_sampler_specs, shuffle, draw_same_chunk,"
-    "batch_size, num_workers, repeat_dataset", [
-        (IMAGE_SPECS[10:12], (32, False), True, False, 2, 2, 1),
-        (IMAGE_SPECS[10:12], (32, False), True, False, 2, 2, 2),
-        (IMAGE_SPECS[10:12], (32, False), True, False, 2, 2, 3),
-    ],
-    indirect=["image_dataset_specs", "patch_sampler_specs"]
-)
-def test_multithread_chained_ZarrDataset(image_dataset_specs,
-                                         patch_sampler_specs,
-                                         shuffle,
-                                         draw_same_chunk,
-                                         batch_size,
-                                         num_workers,
-                                         repeat_dataset):
-    dataset_specs, specs = image_dataset_specs
-    patch_sampler, patch_size, allow_incomplete_patches = patch_sampler_specs
-
-    ds = [zds.ZarrDataset(dataset_specs=dataset_specs,
-                          shuffle=shuffle,
-                          patch_sampler=patch_sampler,
-                          draw_same_chunk=draw_same_chunk
-        )] * repeat_dataset
-
-    chained_ds = ChainDataset(ds)
-
-    dl = DataLoader(
-        chained_ds,
-        batch_size=batch_size,
-        num_workers=num_workers,
-        worker_init_fn=zds.chained_zarrdataset_worker_init_fn,
-        drop_last=True
-    )
-
-    array_idx = 0
-    label_idx = 1
-
-    n_samples = 0
-
-    for sample in dl:
-        n_samples += 1
-        assert isinstance(sample, list), \
-            (f"When a labels dataset specification is passed to ZarrDataset "
-             f"and used with PyTorch DataLoader, samples should be a list, got"
-             f" {type(sample)} instead.")
-
-        assert isinstance(sample[0], torch.Tensor), \
-            (f"Sample should be a PyTorch Tensor, got {type(sample[0])} "
-             f"instead.")
-
-        sample_array = sample[array_idx]
-        labels_array = sample[label_idx]
-
-        expected_shape = [batch_size] + [
-            min(patch_size, specs["shape"][specs["source_axes"].index(ax)])
-            if ax in patch_sampler.spatial_axes else
-            specs["shape"][specs["source_axes"].index(ax)]
-            for ax in specs["source_axes"]
-        ]
-
-        expected_labels_shape = [batch_size] + [
-            patch_size if ax in patch_sampler.spatial_axes else
-            specs["shape"]["YX".index(ax)]
-            for ax in "YX"
-        ]
-
-        assert all(map(operator.eq,
-                       list(sample_array.shape),
-                       expected_shape)), \
-            (f"Sample expected to have shape {expected_shape}, got "
-             f"{sample_array.shape} instead")
-
-        assert all(map(operator.eq,
-                       labels_array.shape,
-                       expected_labels_shape)), \
-            (f"Labels expected to have shape {expected_labels_shape}, got "
-             f"{labels_array.shape} instead")
-
-    assert n_samples > 0, ("Expected more than zero samples extracted from "
-                           "this experiment.")
-
-
-def test_compatibility_no_pytroch():
-    with mock.patch.dict('sys.modules', {'torch': None}):
-        importlib.reload(zds._zarrdataset)
-
-        dataset = zds._zarrdataset.ZarrDataset()
-
-        assert isinstance(object, type(dataset).__bases__), \
-            (f"When pytorch is not installed, ZarrDataset should be inherited"
-             f" from object, not {type(dataset).__bases__}")
-
-        try:
-            zds._zarrdataset.zarrdataset_worker_init_fn(None)
-
-        except Exception as e:
-            raise AssertionError(f"No exceptions where expected when using "
-                                 f"`zarrdataset_worker_init_fn` without "
-                                 f"pytorch installed, got {e} instead.")
-
-        try:
-            zds._zarrdataset.chained_zarrdataset_worker_init_fn(None)
-
-        except Exception as e:
-            raise AssertionError(f"No exceptions where expected when using "
-                                 f"`chained_zarrdataset_worker_init_fn` "
-                                 f"without pytorch installed, got {e} "
-                                 f"instead.")
-    with mock.patch.dict('sys.modules', {'torch': torch}):
-        importlib.reload(zds._zarrdataset)
-        importlib.reload(zds)
+    assert sample[0].dtype == np.float32, \
+        (f"Expected sample to have data type numpy.float32 after applying two "
+         f"consecutive data type transforms, got {sample[0].dtype} instead.")

--- a/zarrdataset/_augs.py
+++ b/zarrdataset/_augs.py
@@ -12,7 +12,7 @@ class ToDtype(object):
     def __init__(self, dtype: np.dtype) -> None:
         self._dtype = dtype
 
-    def __call__(self, image:np.ndarray) -> np.ndarray:
+    def __call__(self, image: np.ndarray) -> np.ndarray:
         """Casts the type of `image` to the data type specified with `dtype`.
 
         Parameters

--- a/zarrdataset/_samplers.py
+++ b/zarrdataset/_samplers.py
@@ -325,7 +325,9 @@ class PatchSampler(object):
 
             patches_coverage = np.sum(covered_indices * coverage, axis=0)
 
-        minimum_covered_tls = image_coordinates[patches_coverage > min_area]
+        patches_coverage = np.round(patches_coverage)
+
+        minimum_covered_tls = image_coordinates[patches_coverage >= min_area]
         minimum_covered_tls = minimum_covered_tls.astype(np.int64)
 
         return minimum_covered_tls

--- a/zarrdataset/_utils.py
+++ b/zarrdataset/_utils.py
@@ -59,7 +59,8 @@ def parse_metadata(filename: str, default_source_axes: str,
                    default_data_group: Union[str, int, None]=None,
                    default_axes: Union[str, None]=None,
                    default_rois: Union[Iterable[slice], None]=None,
-                   override_meta: bool=False) -> List[dict]:
+                   override_meta: bool=False,
+                   **kwargs) -> List[dict]:
     """Parse the filename, data groups, axes ordering, ROIs from `filename`.
 
     The different fields must be separated by a semicolon (;).
@@ -84,6 +85,8 @@ def parse_metadata(filename: str, default_source_axes: str,
     override_meta : bool
         Whether to override the values parsed from the filename with the
         defaults or not.
+    **kwargs : dict
+        Additional named arguments passed to the ImageLoader constructor.
 
     Returns
     -------
@@ -200,7 +203,8 @@ def parse_metadata(filename: str, default_source_axes: str,
          "data_group": data_group,
          "source_axes": source_axes,
          "axes": target_axes,
-         "roi": roi}
+         "roi": roi,
+         **kwargs}
         for roi in rois
     ]
 

--- a/zarrdataset/_zarrdataset.py
+++ b/zarrdataset/_zarrdataset.py
@@ -190,7 +190,8 @@ class DatasetSpecs(dict):
                  image_loader_func: Union[Callable, None] = None,
                  zarr_store: Union[zarr.storage.Store, None] = None,
                  transform: Union[Callable, Iterable[Callable], None] = None,
-                 add_to_output: bool = True):
+                 add_to_output: bool = True,
+                 **kwargs):
 
         super().__init__()
 
@@ -268,7 +269,8 @@ class ImagesDatasetSpecs(DatasetSpecs):
                  image_loader_func: Union[Callable, None] = None,
                  zarr_store: Union[zarr.storage.Store, None] = None,
                  transform: Union[Callable, Iterable[Callable], None] = None,
-                 modality: str ="images"):
+                 modality: str ="images",
+                 **kwargs):
 
         super().__init__(
             modality,
@@ -346,7 +348,8 @@ class LabelsDatasetSpecs(DatasetSpecs):
       transform: Union[Callable, Iterable[Callable], None] = None,
       input_label_transform: Union[Callable, Iterable[Callable], None] = None,
       input_mode: str = "images",
-      modality: str = "labels"):
+      modality: str = "labels",
+      **kwargs):
 
         super().__init__(
             modality,
@@ -744,7 +747,8 @@ class ZarrDataset(IterableDataset):
                      image_loader_func: Union[Callable, None] = None,
                      zarr_store: Union[zarr.storage.Store, None] = None,
                      transforms: Union[Iterable[tuple], None] = None,
-                     add_to_output: bool = True):
+                     add_to_output: bool = True,
+                     **kwargs):
         """Add a new modality to the dataset.
 
         Parameters


### PR DESCRIPTION
Previously "constant" mode was used for filling padded pixels from outside the image, this change would allow to use different modes such as "reflect".
The `padding_mode` can be passed when adding a data mode with `ZarrDataset.add_modality(..., padding_mode="reflect")`.

This PR also enables adding a list of transforms when previously these were overwritten when added with `ZarrDataset.add_transform()`.
With a new argument append, this changes to allow appending sequential transforms.