### PR TITLE
Modified requirements to use zarr<3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ botocore>=1.31.17,<1.31.18
 boto3>=1.28.17,<1.28.18
 fsspec>=2023.9.2
 s3fs>=0.4.2
-zarr>=2.12.0
+zarr>=2.12.0,<3.0
 scikit-image>=0.19.3
 poisson-disc>=0.2.1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         'boto3>=1.28.17,<1.28.18',
         'fsspec>=2023.9.2',
         's3fs>=0.4.2',
-        'zarr>=2.12.0',
+        'zarr>=2.12.0,<3.0',
         'scikit-image>=0.19.3',
         'poisson-disc>=0.2.1',
     ],


### PR DESCRIPTION
Currently, ZarrDataset only works with zarr v2, and would require to change some code to work with zarr v3.

Because of this, the requirements and setup files have been updated to reflect this.